### PR TITLE
Enables the rejection of actions provided by the default and abstract controllers.

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -9,6 +9,7 @@ use Spatie\RouteDiscovery\PendingRouteTransformers\HandleDoNotDiscoverAttribute;
 use Spatie\RouteDiscovery\PendingRouteTransformers\HandleFullUriAttribute;
 use Spatie\RouteDiscovery\PendingRouteTransformers\HandleHttpMethodsAttribute;
 use Spatie\RouteDiscovery\PendingRouteTransformers\HandleMiddlewareAttribute;
+use Spatie\RouteDiscovery\PendingRouteTransformers\HandleRejectDefaultControllerMethodRoutes;
 use Spatie\RouteDiscovery\PendingRouteTransformers\HandleRouteNameAttribute;
 use Spatie\RouteDiscovery\PendingRouteTransformers\HandleUriAttribute;
 use Spatie\RouteDiscovery\PendingRouteTransformers\HandleUrisOfNestedControllers;
@@ -35,6 +36,7 @@ class Config
             AddDefaultRouteName::class,
             HandleDomainAttribute::class,
             MoveRoutesStartingWithParametersLast::class,
+            HandleRejectDefaultControllerMethodRoutes::class,
         ];
     }
 }

--- a/src/PendingRouteTransformers/HandleRejectDefaultControllerMethodRoutes.php
+++ b/src/PendingRouteTransformers/HandleRejectDefaultControllerMethodRoutes.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Spatie\RouteDiscovery\PendingRouteTransformers;
+
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Collection;
+use Spatie\RouteDiscovery\PendingRoutes\PendingRoute;
+use Spatie\RouteDiscovery\PendingRoutes\PendingRouteAction;
+
+class HandleRejectDefaultControllerMethodRoutes implements PendingRouteTransformer
+{
+    /**
+     * Array of FQCN of the classes that methods should be ignored.
+     *
+     * @var array|string[]
+     */
+    public array $candidates = [
+        // This is the classname on the test, didn't want to mess with autoloading.
+        'Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\DefaultController\Controller',
+        // This is the classname on the production project
+        'App\Http\Controllers\Controller',
+        Controller::class,
+    ];
+
+    /**
+     * @param Collection<PendingRoute> $pendingRoutes
+     *
+     * @return Collection<PendingRoute>
+     */
+    public function transform(Collection $pendingRoutes): Collection
+    {
+        return $pendingRoutes->each(function (PendingRoute $pendingRoute) {
+            // Remove every action that is from the default or abstract controller.
+            $pendingRoute->actions = $pendingRoute
+                ->actions
+                ->reject(fn(PendingRouteAction $pendingRouteAction) => in_array(
+                    $pendingRouteAction->method->class, $this->candidates
+                ));
+        });
+    }
+}

--- a/tests/DiscoverControllersTest.php
+++ b/tests/DiscoverControllersTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Route;
 use Spatie\RouteDiscovery\Discovery\Discover;
 use Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\CustomMethod\CustomMethodController;
+use Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\DefaultController\WelcomeController;
 use Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\Single\MyController;
 
 it('can discover controller in a directory', function () {
@@ -17,6 +18,21 @@ it('can discover controller in a directory', function () {
             MyController::class,
             controllerMethod: 'index',
             uri: 'my',
+        );
+});
+
+it('does not discover routes on base controller extension', function () {
+    Discover::controllers()
+        ->useRootNamespace('Spatie\RouteDiscovery\Tests\\')
+        ->useBasePath($this->getTestPath())
+        ->in(controllersPath('DefaultController'));
+
+    $this
+        ->assertRegisteredRoutesCount(1)
+        ->assertRouteRegistered(
+            WelcomeController::class,
+            controllerMethod: 'index',
+            uri: 'welcome',
         );
 });
 

--- a/tests/DiscoverControllersTest.php
+++ b/tests/DiscoverControllersTest.php
@@ -21,7 +21,7 @@ it('can discover controller in a directory', function () {
         );
 });
 
-it('does not discover routes on base controller extension', function () {
+it('does not discover routes on default and abstract controller', function () {
     Discover::controllers()
         ->useRootNamespace('Spatie\RouteDiscovery\Tests\\')
         ->useBasePath($this->getTestPath())

--- a/tests/Support/TestClasses/Controllers/DefaultController/Controller.php
+++ b/tests/Support/TestClasses/Controllers/DefaultController/Controller.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\DefaultController;
+
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Foundation\Bus\DispatchesJobs;
+use Illuminate\Foundation\Validation\ValidatesRequests;
+use Illuminate\Routing\Controller as BaseController;
+
+/**
+ * Class Controller, exacly like the default Laravel controller. BUT with different namespace.
+ *
+ */
+class Controller extends BaseController
+{
+    use AuthorizesRequests, DispatchesJobs, ValidatesRequests;
+}

--- a/tests/Support/TestClasses/Controllers/DefaultController/WelcomeController.php
+++ b/tests/Support/TestClasses/Controllers/DefaultController/WelcomeController.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\DefaultController;
+
+class WelcomeController extends Controller
+{
+    public function index()
+    {
+        return 'I am a Welcome Controller.';
+    }
+}


### PR DESCRIPTION
Hello!

This PR addresses #8 

This PR adds the functionality of rejecting PendingActions that have origin in classes:
- `Illuminate\Routing\Controller`
- `App\Http\Controllers\Controller`
and also
- `Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\DefaultController\Controller`

I made this controller, to mimic the absent `App\Http\Controllers\Controller`.
As an alternative, we could change the `autoload-dev`, and add this namespace exactly.
Would you want that??

I used a default Transformer to make the implementation and added it to the default stack.
If you don't like it for some reason, perhaps we could just ship the transformer, and opt-in would be to add it manually in the project.

It was a delight to work with this package, and also my first experience with Pest. 

Loved it, thank you!!