### PR TITLE
Change to allow forward-slashes in Windows

### DIFF
--- a/src/PendingRoutes/PendingRouteFactory.php
+++ b/src/PendingRoutes/PendingRouteFactory.php
@@ -46,7 +46,7 @@ class PendingRouteFactory
     protected function discoverUri(ReflectionClass $class): string
     {
         $parts = Str::of((string) $class->getFileName())
-            ->after($this->registeringDirectory)
+            ->after(str_replace('/', DIRECTORY_SEPARATOR, $this->registeringDirectory))
             ->beforeLast('Controller')
             ->explode(DIRECTORY_SEPARATOR);
 


### PR DESCRIPTION
Fixes #12 . This uses str_replace to guarantee that forward slashes are transformed to DIRECTORY_SEPARATORs instead.