### PR TITLE
Partial fix to default route name generation

### DIFF
--- a/src/PendingRouteTransformers/AddDefaultRouteName.php
+++ b/src/PendingRouteTransformers/AddDefaultRouteName.php
@@ -27,7 +27,8 @@ class AddDefaultRouteName implements PendingRouteTransformer
 
     protected function generateRouteName(PendingRouteAction $pendingRouteAction): string
     {
-        return collect(explode('/', $pendingRouteAction->uri))
+        return collect([explode('/', $pendingRouteAction->uri), $pendingRouteAction->method->name])
+            ->flatten()
             ->reject(fn (string $segment) => str_starts_with($segment, '{'))
             ->join('.');
     }


### PR DESCRIPTION
This PR is related to the issue #16.

The following code solved my original problem in my personal project, but while doing `composer test` on my fork one test fails because passed value `$pendingRouteAction->uri` already contains method name.

PR was requested by @freekmurze to see progress.