### PR TITLE
Fix issue where union typed parameters caused discovery errors

### DIFF
--- a/src/PendingRoutes/PendingRouteAction.php
+++ b/src/PendingRoutes/PendingRouteAction.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use ReflectionAttribute;
 use ReflectionMethod;
+use ReflectionNamedType;
 use ReflectionParameter;
 use Spatie\RouteDiscovery\Attributes\DiscoveryAttribute;
 use Spatie\RouteDiscovery\Attributes\Route;
@@ -50,8 +51,8 @@ class PendingRouteAction
     {
         /** @var ReflectionParameter $modelParameter */
         $modelParameter = collect($this->method->getParameters())->first(function (ReflectionParameter $parameter) {
-            /** @phpstan-ignore-next-line */
-            return is_a($parameter->getType()?->getName(), Model::class, true);
+            $type = $parameter->getType();
+            return $type instanceof ReflectionNamedType && is_a($type->getName(), Model::class, true);
         });
 
         $uri = '';

--- a/tests/DiscoverControllersTest.php
+++ b/tests/DiscoverControllersTest.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Facades\Route;
 use Spatie\RouteDiscovery\Discovery\Discover;
 use Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\CustomMethod\CustomMethodController;
 use Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\DefaultController\ControllerThatExtendsDefaultController;
+use Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\UsesUnionTypes\UnionController;
 use Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\Single\MyController;
 
 it('can discover controller in a directory', function () {
@@ -67,3 +68,19 @@ it('can use a prefix when discovering routes', function () {
             uri: 'my-prefix/my',
         );
 });
+
+it('can handle a union parameter', function() {
+    Discover::controllers()
+        ->useRootNamespace('Spatie\RouteDiscovery\Tests\\')
+        ->useBasePath($this->getTestPath())
+        ->in(controllersPath('UsesUnionTypes'));
+
+    $this
+        ->assertRegisteredRoutesCount(1)
+        ->assertRouteRegistered(
+            UnionController::class,
+            controllerMethod: 'example',
+            uri: 'union/example',
+        );
+});
+

--- a/tests/Support/TestClasses/Controllers/UsesUnionTypes/UnionController.php
+++ b/tests/Support/TestClasses/Controllers/UsesUnionTypes/UnionController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\UsesUnionTypes;
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Routing\Redirector;
+
+class UnionController
+{
+    public function example(Redirector|RedirectResponse $example): Redirector|RedirectResponse
+    {
+        return $example;
+    }
+}


### PR DESCRIPTION
One of my controllers had a function that could be passed a union type, this caused an error during discovery:

```
   Error 

  Call to undefined method ReflectionUnionType::getName()

  at vendor/spatie/laravel-route-discovery/src/PendingRoutes/PendingRouteAction.php:54
     50▕     {
     51▕         /** @var ReflectionParameter $modelParameter */
     52▕         $modelParameter = collect($this->method->getParameters())->first(function (ReflectionParameter $parameter) {
     53▕             /** @phpstan-ignore-next-line */
  ➜  54▕             return is_a($parameter->getType()?->getName(), Model::class, true);
     55▕         });
     56▕ 
     57▕         $uri = '';
     58▕ 
```

This PR fixes the issue by ensuring the type is a `ReflectionNamedType` before attempting to call `getName()` on it.