### PR TITLE
Exclude method "middleware" from discovered routes

### DIFF
--- a/src/PendingRouteTransformers/RejectDefaultControllerMethodRoutes.php
+++ b/src/PendingRouteTransformers/RejectDefaultControllerMethodRoutes.php
@@ -30,10 +30,16 @@ class RejectDefaultControllerMethodRoutes implements PendingRouteTransformer
         return $pendingRoutes->each(function (PendingRoute $pendingRoute) {
             $pendingRoute->actions = $pendingRoute
                 ->actions
-                ->reject(fn (PendingRouteAction $pendingRouteAction) => in_array(
-                    $pendingRouteAction->method->class,
-                    $this->rejectMethodsInClasses
-                ));
+                ->reject(function (PendingRouteAction $pendingRouteAction) {
+                    if($pendingRouteAction->method->name == "middleware" && is_subclass_of($pendingRouteAction->method->class, "Illuminate\\Routing\\Controllers\\HasMiddleware")){
+                        return true;
+                    }
+
+                    return in_array(
+                        $pendingRouteAction->method->class,
+                        $this->rejectMethodsInClasses
+                    );
+                });
         });
     }
 }

--- a/tests/RouteDiscoveryTest.php
+++ b/tests/RouteDiscoveryTest.php
@@ -449,6 +449,10 @@ it('can avoid discovering a method', function () {
 });
 
 it('can avoid discovering the laravel middleware method', function () {
+    if(!interface_exists('Illuminate\Routing\Controllers\HasMiddleware')) {
+        $this->markTestSkipped("Laravel 9 or up is required to run this test.");
+    }
+    
     $this
         ->routeRegistrar
         ->registerDirectory(controllersPath('DoNotDiscoverMiddleware'));

--- a/tests/RouteDiscoveryTest.php
+++ b/tests/RouteDiscoveryTest.php
@@ -8,6 +8,8 @@ use Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\DefaultRouteName
 use Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\Domain\DomainController;
 use Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\DoNotDiscoverController\DoNotDiscoverThisMethodController;
 use Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\DoNotDiscoverMethod\DoNotDiscoverMethodController;
+use Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\DoNotDiscoverMiddleware\DiscoverMiddlewareIfNotLaravelMethodController;
+use Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\DoNotDiscoverMiddleware\DoNotDiscoverMiddlewareController;
 use Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\Invokable\InvokableController;
 use Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\Middleware\MiddlewareOnControllerController;
 use Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\Middleware\MiddlewareOnMethodController;
@@ -271,7 +273,6 @@ it('will register routes with the correct names for resourceful methods without 
         );
 });
 
-
 it('can override the http method', function () {
     $this
         ->routeRegistrar
@@ -355,6 +356,30 @@ it('can avoid discovering a method', function () {
             DoNotDiscoverMethodController::class,
             controllerMethod: 'method',
             uri: 'do-not-discover-method/method',
+        );
+});
+
+it('can avoid discovering the laravel middleware method', function () {
+    $this
+        ->routeRegistrar
+        ->registerDirectory(controllersPath('DoNotDiscoverMiddleware'));
+
+    $this
+        ->assertRegisteredRoutesCount(3)
+        ->assertRouteRegistered(
+            DoNotDiscoverMiddlewareController::class,
+            controllerMethod: 'method',
+            uri: 'do-not-discover-middleware/method',
+        )
+        ->assertRouteRegistered(
+            DiscoverMiddlewareIfNotLaravelMethodController::class,
+            controllerMethod: 'method',
+            uri: 'discover-middleware-if-not-laravel-method/method',
+        )
+        ->assertRouteRegistered(
+            DiscoverMiddlewareIfNotLaravelMethodController::class,
+            controllerMethod: 'middleware',
+            uri: 'discover-middleware-if-not-laravel-method/middleware',
         );
 });
 
@@ -461,7 +486,7 @@ it('will make sure the routes whose uri start with parameters will be registered
     $this->assertRegisteredRoutesCount(3);
 
     $registeredUris = collect(app()->router->getRoutes())
-        ->map(fn (Route $route) => $route->uri)
+        ->map(fn(Route $route) => $route->uri)
         ->toArray();
 
     expect($registeredUris)->toEqual([

--- a/tests/Support/TestClasses/Controllers/DoNotDiscoverMiddleware/DiscoverMiddlewareIfNotLaravelMethodController.php
+++ b/tests/Support/TestClasses/Controllers/DoNotDiscoverMiddleware/DiscoverMiddlewareIfNotLaravelMethodController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\DoNotDiscoverMiddleware;
+
+class DiscoverMiddlewareIfNotLaravelMethodController
+{
+    public static function middleware(): array {
+        return [];
+    }
+
+    public function method()
+    {
+    }
+
+}

--- a/tests/Support/TestClasses/Controllers/DoNotDiscoverMiddleware/DoNotDiscoverMiddlewareController.php
+++ b/tests/Support/TestClasses/Controllers/DoNotDiscoverMiddleware/DoNotDiscoverMiddlewareController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\DoNotDiscoverMiddleware;
+
+use Illuminate\Routing\Controllers\HasMiddleware;
+
+class DoNotDiscoverMiddlewareController implements HasMiddleware
+{
+    public static function middleware(): array {
+        return [];
+    }
+
+    public function method()
+    {
+    }
+
+}


### PR DESCRIPTION
### Description

In Laravel 11, an interface has been added that allows middleware to be defined via a method. This package, which automatically detects routes in controllers, should exclude this new method since it returns all middleware classes.

### Changes
- Updated the route detection logic to exclude the new middleware method introduced in Laravel 11.

### Reason
The new method in Laravel 11's controllers that returns all middleware classes should not be included in the automatic route detection, as it does not define actual routes.

### Additional Notes
Please review the changes and provide any feedback or suggestions for improvement.

Thank you!