### PR TITLE
Handle multiple model parameters in routes.

### DIFF
--- a/src/PendingRouteTransformers/HandleUrisOfNestedControllers.php
+++ b/src/PendingRouteTransformers/HandleUrisOfNestedControllers.php
@@ -42,10 +42,13 @@ class HandleUrisOfNestedControllers implements PendingRouteTransformer
                             fn (ReflectionParameter $parentParameter) => $parentParameter->getName() === $parameter->getName())
                     );
                 $result = Str::of($action->uri)
-                    ->replace($paramsToRemove->implode(fn (ReflectionParameter $parameter) => "{{$parameter->getName()}}"), '')
+                    ->replace(
+                        $paramsToRemove->map(fn (ReflectionParameter $parameter) => "{{$parameter->getName()}}")->toArray(),
+                        ''
+                    )
                     ->replace('//', '/')
-                    ->replace($parentPendingRoute->uri, $parentAction->uri)
-                    ->toString();
+                    ->replace($parentPendingRoute->uri, $parentAction->uri);
+
                 $action->uri = $result;
             });
         });

--- a/src/PendingRouteTransformers/HandleUrisOfNestedControllers.php
+++ b/src/PendingRouteTransformers/HandleUrisOfNestedControllers.php
@@ -4,6 +4,7 @@ namespace Spatie\RouteDiscovery\PendingRouteTransformers;
 
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use ReflectionParameter;
 use Spatie\RouteDiscovery\PendingRoutes\PendingRoute;
 use Spatie\RouteDiscovery\PendingRoutes\PendingRouteAction;
 
@@ -33,8 +34,18 @@ class HandleUrisOfNestedControllers implements PendingRouteTransformer
             }
 
             $childNode->actions->each(function (PendingRouteAction $action) use ($parentPendingRoute, $parentAction) {
-                $result = Str::replace($parentPendingRoute->uri, $parentAction->uri, $action->uri);
-
+                $paramsToRemove = $action->modelParameters()
+                    ->filter(
+                        fn (ReflectionParameter $parameter) => $parentAction
+                        ->modelParameters()
+                        ->contains(
+                            fn (ReflectionParameter $parentParameter) => $parentParameter->getName() === $parameter->getName())
+                    );
+                $result = Str::of($action->uri)
+                    ->replace($paramsToRemove->implode(fn (ReflectionParameter $parameter) => "{{$parameter->getName()}}"), '')
+                    ->replace('//', '/')
+                    ->replace($parentPendingRoute->uri, $parentAction->uri)
+                    ->toString();
                 $action->uri = $result;
             });
         });

--- a/src/PendingRoutes/PendingRouteAction.php
+++ b/src/PendingRoutes/PendingRouteAction.php
@@ -77,7 +77,9 @@ class PendingRouteAction
             if ($uri !== '') {
                 $uri .= '/';
             }
-            $uri .= $this->modelParameters->implode(fn(ReflectionParameter $parameter) =>"{{$parameter->getName()}}", '/');
+            $uri .= $this->modelParameters
+                ->map(fn(ReflectionParameter $parameter) => "{{$parameter->getName()}}")
+                ->implode('/');
         }
 
         return $uri;

--- a/src/PendingRoutes/PendingRouteAction.php
+++ b/src/PendingRoutes/PendingRouteAction.php
@@ -4,6 +4,7 @@ namespace Spatie\RouteDiscovery\PendingRoutes;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use ReflectionAttribute;
 use ReflectionMethod;
@@ -19,6 +20,9 @@ class PendingRouteAction
     public string $uri;
     /** @var array<int, string> */
     public array $methods = [];
+
+    /** @var Collection<ReflectionParameter> */
+    public Collection $modelParameters;
 
     /** @var array{class-string, string} */
     public array $action;
@@ -40,6 +44,8 @@ class PendingRouteAction
     {
         $this->method = $method;
 
+        $this->modelParameters = $this->modelParameters();
+
         $this->uri = $this->relativeUri();
 
         $this->methods = $this->discoverHttpMethods();
@@ -47,28 +53,31 @@ class PendingRouteAction
         $this->action = [$controllerClass, $method->name];
     }
 
-    public function relativeUri(): string
+    /**
+     * @return Collection<ReflectionParameter>
+     */
+    public function modelParameters(): Collection
     {
-        /** @var ReflectionParameter $modelParameter */
-        $modelParameter = collect($this->method->getParameters())->first(function (ReflectionParameter $parameter) {
+        return collect($this->method->getParameters())->filter(function (ReflectionParameter $parameter) {
             $type = $parameter->getType();
 
             return $type instanceof ReflectionNamedType && is_a($type->getName(), Model::class, true);
         });
+    }
 
+    public function relativeUri(): string
+    {
         $uri = '';
 
         if (! in_array($this->method->getName(), $this->commonControllerMethodNames())) {
             $uri = Str::kebab($this->method->getName());
         }
 
-        /** @phpstan-ignore-next-line */
-        if ($modelParameter) {
+        if ($this->modelParameters->isNotEmpty()) {
             if ($uri !== '') {
                 $uri .= '/';
             }
-
-            $uri .= "{{$modelParameter->getName()}}";
+            $uri .= $this->modelParameters->implode(fn(ReflectionParameter $parameter) =>"{{$parameter->getName()}}", '/');
         }
 
         return $uri;

--- a/tests/RouteDiscoveryTest.php
+++ b/tests/RouteDiscoveryTest.php
@@ -12,6 +12,9 @@ use Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\Invokable\Invoka
 use Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\Middleware\MiddlewareOnControllerController;
 use Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\Middleware\MiddlewareOnMethodController;
 use Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\Model\ModelController;
+use Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\MultipleModel\MultipleModelController;
+use Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\NestedWithMultipleParametersController\PhotosController as MpPhotosController;
+use Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\NestedWithMultipleParametersController\Photos\CommentsController as MpCommentsController;
 use Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\NestedWithParametersController\Photos\CommentsController;
 use Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\NestedWithParametersController\PhotosController;
 use Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\Nesting\Nested\ChildController;
@@ -120,6 +123,43 @@ it('can automatically discover a nested route with model parameters', function (
     );
 });
 
+it('can automatically discover a nested route with multiple model parameters', function () {
+    $this
+        ->routeRegistrar
+        ->registerDirectory(controllersPath('NestedWithMultipleParametersController'));
+
+    $this->assertRegisteredRoutesCount(5);
+
+    $this->assertRouteRegistered(
+        MpPhotosController::class,
+        controllerMethod: 'show',
+        uri: 'photos/{photo}',
+    );
+
+    $this->assertRouteRegistered(
+        MpPhotosController::class,
+        controllerMethod: 'edit',
+        uri: 'photos/edit/{photo}',
+    );
+
+    $this->assertRouteRegistered(
+        MpCommentsController::class,
+        controllerMethod: 'show',
+        uri: 'photos/{photo}/comments/{comment}',
+    );
+    $this->assertRouteRegistered(
+        MpCommentsController::class,
+        controllerMethod: 'edit',
+        uri: 'photos/{photo}/comments/edit/{comment}',
+    );
+    $this->assertRouteRegistered(
+        MpCommentsController::class,
+        controllerMethod: 'store',
+        httpMethods: 'post',
+        uri: 'photos/{photo}/comments/{comment}',
+    );
+});
+
 it('can automatically discovery a model route', function () {
     $this
         ->routeRegistrar
@@ -131,6 +171,20 @@ it('can automatically discovery a model route', function () {
             ModelController::class,
             controllerMethod: 'edit',
             uri: 'model/edit/{user}',
+        );
+});
+
+it('can automatically discovery multiple model route', function () {
+    $this
+        ->routeRegistrar
+        ->registerDirectory(controllersPath('MultipleModel'));
+
+    $this
+        ->assertRegisteredRoutesCount(1)
+        ->assertRouteRegistered(
+            MultipleModelController::class,
+            controllerMethod: 'edit',
+            uri: 'multiple-model/edit/{user}/{photo}',
         );
 });
 

--- a/tests/Support/TestClasses/Controllers/MultipleModel/MultipleModelController.php
+++ b/tests/Support/TestClasses/Controllers/MultipleModel/MultipleModelController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\MultipleModel;
+
+use Spatie\RouteDiscovery\Tests\Support\TestClasses\Models\Photo;
+use Spatie\RouteDiscovery\Tests\Support\TestClasses\Models\User;
+
+class MultipleModelController
+{
+    public function edit(User $user, Photo $photo)
+    {
+    }
+}

--- a/tests/Support/TestClasses/Controllers/NestedWithMultipleParametersController/Photos/CommentsController.php
+++ b/tests/Support/TestClasses/Controllers/NestedWithMultipleParametersController/Photos/CommentsController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\NestedWithMultipleParametersController\Photos;
+
+use Spatie\RouteDiscovery\Tests\Support\TestClasses\Models\Comment;
+use Spatie\RouteDiscovery\Tests\Support\TestClasses\Models\Photo;
+use Spatie\RouteDiscovery\Tests\Support\TestClasses\Models\User;
+
+class CommentsController
+{
+    public function show(Photo $photo, Comment $comment)
+    {
+    }
+
+    public function edit(Photo $photo, Comment $comment)
+    {
+    }
+
+    public function store(Photo $photo, Comment $comment)
+    {
+    }
+}

--- a/tests/Support/TestClasses/Controllers/NestedWithMultipleParametersController/PhotosController.php
+++ b/tests/Support/TestClasses/Controllers/NestedWithMultipleParametersController/PhotosController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\NestedWithMultipleParametersController;
+
+use Spatie\RouteDiscovery\Tests\Support\TestClasses\Models\Photo;
+
+class PhotosController
+{
+    public function show(Photo $photo)
+    {
+    }
+
+    public function edit(Photo $photo)
+    {
+    }
+}


### PR DESCRIPTION
Hi!

I've enhanced the routing system to support multiple parameters in routes. 
Additionally, when dealing with nested controllers, if a parameter is already present in the parent route, it gets filtered out from the child route. This allows developers to specify all parameters directly in the controller method.

For example:
```php
class ModelController
{
    public function edit(User $user, Photo $photo) {}
}
```
the route is:
```
model/edit/{user}/{photo}
```

With nested Controller:
```php
// path: Controllers/PhotosController
class PhotosController
{
    public function show(Photo $photo) {}
}

// path: Controllers/Photos/CommentsController
class CommentsController
{
    public function show(Photo $photo, Comment $comment) {}
}
```
the route is:
```
photos/{photo}
photos/{photo}/comments/{comment}
```



