### PR TITLE
Added filter to remove extra dot in nested route names

### DIFF
--- a/src/PendingRouteTransformers/AddDefaultRouteName.php
+++ b/src/PendingRouteTransformers/AddDefaultRouteName.php
@@ -29,6 +29,7 @@ class AddDefaultRouteName implements PendingRouteTransformer
     {
         return collect(explode('/', $pendingRouteAction->uri))
             ->reject(fn (string $segment) => str_starts_with($segment, '{'))
+            ->filter()
             ->when(
                 $this->discoverMethodRouteName($pendingRouteAction),
                 fn (Collection $collection, $name) => $name != $collection->last() ? $collection->push($name) : $collection

--- a/tests/RouteDiscoveryTest.php
+++ b/tests/RouteDiscoveryTest.php
@@ -128,35 +128,70 @@ it('can automatically discover a nested route with multiple model parameters', f
         ->routeRegistrar
         ->registerDirectory(controllersPath('NestedWithMultipleParametersController'));
 
-    $this->assertRegisteredRoutesCount(5);
+    $this->assertRegisteredRoutesCount(9);
 
     $this->assertRouteRegistered(
         MpPhotosController::class,
         controllerMethod: 'show',
         uri: 'photos/{photo}',
+        name: 'photos.show',
     );
 
     $this->assertRouteRegistered(
         MpPhotosController::class,
         controllerMethod: 'edit',
         uri: 'photos/edit/{photo}',
+        name: 'photos.edit',
     );
 
     $this->assertRouteRegistered(
         MpCommentsController::class,
-        controllerMethod: 'show',
-        uri: 'photos/{photo}/comments/{comment}',
+        controllerMethod: 'index',
+        httpMethods: 'get',
+        uri: 'photos/{photo}/comments',
+        name: 'photos.comments',
     );
     $this->assertRouteRegistered(
         MpCommentsController::class,
-        controllerMethod: 'edit',
-        uri: 'photos/{photo}/comments/edit/{comment}',
+        controllerMethod: 'show',
+        httpMethods: 'get',
+        uri: 'photos/{photo}/comments/{comment}',
+        name: 'photos.comments.show',
+    );
+    $this->assertRouteRegistered(
+        MpCommentsController::class,
+        controllerMethod: 'create',
+        httpMethods: 'get',
+        uri: 'photos/{photo}/comments/create',
+        name: 'photos.comments.create',
     );
     $this->assertRouteRegistered(
         MpCommentsController::class,
         controllerMethod: 'store',
         httpMethods: 'post',
+        uri: 'photos/{photo}/comments',
+        name: 'photos.comments.store',
+    );
+    $this->assertRouteRegistered(
+        MpCommentsController::class,
+        controllerMethod: 'edit',
+        httpMethods: 'get',
+        uri: 'photos/{photo}/comments/edit/{comment}',
+        name: 'photos.comments.edit',
+    );
+    $this->assertRouteRegistered(
+        MpCommentsController::class,
+        controllerMethod: 'update',
+        httpMethods: 'patch',
         uri: 'photos/{photo}/comments/{comment}',
+        name: 'photos.comments.update',
+    );
+    $this->assertRouteRegistered(
+        MpCommentsController::class,
+        controllerMethod: 'destroy',
+        httpMethods: ['delete'],
+        uri: 'photos/{photo}/comments/{comment}',
+        name: 'photos.comments.destroy',
     );
 });
 

--- a/tests/Support/TestClasses/Controllers/NestedWithMultipleParametersController/Photos/CommentsController.php
+++ b/tests/Support/TestClasses/Controllers/NestedWithMultipleParametersController/Photos/CommentsController.php
@@ -2,12 +2,26 @@
 
 namespace Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\NestedWithMultipleParametersController\Photos;
 
+use Illuminate\Http\Request;
 use Spatie\RouteDiscovery\Tests\Support\TestClasses\Models\Comment;
 use Spatie\RouteDiscovery\Tests\Support\TestClasses\Models\Photo;
+use Spatie\RouteDiscovery\Tests\Support\TestClasses\Models\User;
 
 class CommentsController
 {
+    public function index(Photo $photo)
+    {
+    }
+
     public function show(Photo $photo, Comment $comment)
+    {
+    }
+
+    public function create(Photo $photo)
+    {
+    }
+
+    public function store(Photo $photo, Request $request)
     {
     }
 
@@ -15,7 +29,11 @@ class CommentsController
     {
     }
 
-    public function store(Photo $photo, Comment $comment)
+    public function update(Photo $photo, Comment $comment, Request $request)
+    {
+    }
+
+    public function destroy(Photo $photo, Comment $comment)
     {
     }
 }


### PR DESCRIPTION
Hi,
for nested resource there was extra dots in route names.
for example: 
```
photos/{photo}/comments                 photos.comments.
photos/{photo}/comments                 photos.comments..store
```

This PR add a filter to remove them

```
photos/{photo}/comments                 photos.comments
photos/{photo}/comments                 photos.comments.store
```

Thanks.