### PR TITLE
Handle multiple nested routes

### DIFF
--- a/src/PendingRouteTransformers/HandleUrisOfNestedControllers.php
+++ b/src/PendingRouteTransformers/HandleUrisOfNestedControllers.php
@@ -11,9 +11,9 @@ use Spatie\RouteDiscovery\PendingRoutes\PendingRouteAction;
 class HandleUrisOfNestedControllers implements PendingRouteTransformer
 {
     /**
-     * @param Collection<PendingRoute> $pendingRoutes
+     * @param Collection<int, PendingRoute> $pendingRoutes
      *
-     * @return Collection<PendingRoute>
+     * @return Collection<int, PendingRoute>
      */
     public function transform(Collection $pendingRoutes): Collection
     {
@@ -60,9 +60,9 @@ class HandleUrisOfNestedControllers implements PendingRouteTransformer
     }
 
     /**
-     * @param Collection $pendingRoutes
+     * @param Collection<int, PendingRoute> $pendingRoutes
      * @param PendingRoute $parentRouteAction
-     * @return Collection<PendingRoute>
+     * @return Collection<int, PendingRoute>
      */
     protected function findChild(Collection $pendingRoutes, PendingRoute $parentRouteAction): Collection
     {

--- a/tests/RouteDiscoveryTest.php
+++ b/tests/RouteDiscoveryTest.php
@@ -16,6 +16,7 @@ use Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\MultipleModel\Mu
 use Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\NestedWithMultipleParametersController\Photos\CommentsController as MpCommentsController;
 use Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\NestedWithMultipleParametersController\PhotosController as MpPhotosController;
 use Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\NestedWithParametersController\Photos\CommentsController;
+use Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\NestedWithParametersController\Photos\UsersController;
 use Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\NestedWithParametersController\PhotosController;
 use Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\Nesting\Nested\ChildController;
 use Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\Nesting\Nested\Deepest\IndexController as DeepestIndexController;
@@ -97,7 +98,7 @@ it('can automatically discover a nested route with model parameters', function (
         ->routeRegistrar
         ->registerDirectory(controllersPath('NestedWithParametersController'));
 
-    $this->assertRegisteredRoutesCount(4);
+    $this->assertRegisteredRoutesCount(6);
 
     $this->assertRouteRegistered(
         PhotosController::class,
@@ -120,6 +121,17 @@ it('can automatically discover a nested route with model parameters', function (
         CommentsController::class,
         controllerMethod: 'edit',
         uri: 'photos/{photo}/comments/edit/{comment}',
+    );
+
+    $this->assertRouteRegistered(
+        UsersController::class,
+        controllerMethod: 'show',
+        uri: 'photos/{photo}/users/{user}',
+    );
+    $this->assertRouteRegistered(
+        UsersController::class,
+        controllerMethod: 'edit',
+        uri: 'photos/{photo}/users/edit/{user}',
     );
 });
 

--- a/tests/Support/TestClasses/Controllers/NestedWithParametersController/Photos/UsersController.php
+++ b/tests/Support/TestClasses/Controllers/NestedWithParametersController/Photos/UsersController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\NestedWithParametersController\Photos;
+
+use Spatie\RouteDiscovery\Tests\Support\TestClasses\Models\User;
+
+class UsersController
+{
+    public function show(User $user)
+    {
+    }
+
+    public function edit(User $user)
+    {
+    }
+}


### PR DESCRIPTION
Hi
In case of multiple child controller, add the parent to each children
For example:
```
PhotosController.php
Photos/CommentsController.php
Photos/UsersController.php
```
the routes are:
```
photos/{photo}
photos/edit/{photo}
photos/{photo}/users/{user}
photos/{photo}/users/edit/{user}
photos/{photo}/comments/{comment}
photos/{photo}/comments/edit/{comment}
```

This fixes #35 issue

