### PR TITLE
Add support for soft deleted models in route attributes "withTrashed"

### DIFF
--- a/docs/discovering-routes-for-controllers/mapping-controllers-to-routes.md
+++ b/docs/discovering-routes-for-controllers/mapping-controllers-to-routes.md
@@ -262,6 +262,27 @@ class ExampleController
 }
 ```
 
+## Soft Deleted Models
+
+You can instruct the implicit binding to retrieve soft deleted models by passing `true` to the `withTrashed` parameter of the `Route` attribute. This can be done on both the class and method level.
+
+Using this controller, the route to  `restore` will retrieve soft deleted users.
+
+```php
+namespace App\Http\Controllers;
+
+use Illuminate\Routing\Middleware\ValidateSignature;
+use Spatie\RouteDiscovery\Attributes\Route;
+
+class ExampleController
+{
+    public function delete(User $user) { /* ... */ }
+
+    #[Route(withTrashed: true)]
+    public function restore(User $user) { /* ... */ }
+}
+```
+
 ## Preventing routes from being discovered
 
 You can prevent a certain controller from being discovered by using the `DoNotDiscover` attribute.

--- a/src/Attributes/Route.php
+++ b/src/Attributes/Route.php
@@ -29,6 +29,7 @@ class Route implements DiscoveryAttribute
         public ?string $name = null,
         array | string $middleware = [],
         public ?string $domain = null,
+        public bool $withTrashed = false,
     ) {
         $methods = Arr::wrap($method);
 

--- a/src/Attributes/WithTrashed.php
+++ b/src/Attributes/WithTrashed.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Spatie\RouteDiscovery\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD)]
+class WithTrashed implements DiscoveryAttribute
+{
+}

--- a/src/Config.php
+++ b/src/Config.php
@@ -12,6 +12,7 @@ use Spatie\RouteDiscovery\PendingRouteTransformers\HandleMiddlewareAttribute;
 use Spatie\RouteDiscovery\PendingRouteTransformers\HandleRouteNameAttribute;
 use Spatie\RouteDiscovery\PendingRouteTransformers\HandleUriAttribute;
 use Spatie\RouteDiscovery\PendingRouteTransformers\HandleUrisOfNestedControllers;
+use Spatie\RouteDiscovery\PendingRouteTransformers\HandleWithTrashedAttribute;
 use Spatie\RouteDiscovery\PendingRouteTransformers\HandleWheresAttribute;
 use Spatie\RouteDiscovery\PendingRouteTransformers\MoveRoutesStartingWithParametersLast;
 use Spatie\RouteDiscovery\PendingRouteTransformers\RejectDefaultControllerMethodRoutes;
@@ -33,6 +34,7 @@ class Config
             HandleHttpMethodsAttribute::class,
             HandleUriAttribute::class,
             HandleFullUriAttribute::class,
+            HandleWithTrashedAttribute::class,
             HandleWheresAttribute::class,
             AddDefaultRouteName::class,
             HandleDomainAttribute::class,

--- a/src/PendingRouteTransformers/HandleWithTrashedAttribute.php
+++ b/src/PendingRouteTransformers/HandleWithTrashedAttribute.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Spatie\RouteDiscovery\PendingRouteTransformers;
+
+use Illuminate\Support\Collection;
+use Spatie\RouteDiscovery\Attributes\Route;
+use Spatie\RouteDiscovery\PendingRoutes\PendingRoute;
+use Spatie\RouteDiscovery\PendingRoutes\PendingRouteAction;
+
+class HandleWithTrashedAttribute implements PendingRouteTransformer
+{
+    /**
+     * @param Collection<int, PendingRoute> $pendingRoutes
+     *
+     * @return Collection<int, PendingRoute>
+     */
+    public function transform(Collection $pendingRoutes): Collection
+    {
+        return $pendingRoutes->each(function (PendingRoute $pendingRoute) {
+            $pendingRoute->actions->each(function (PendingRouteAction $action) use ($pendingRoute) {
+                if ($pendingRouteAttribute = $pendingRoute->getRouteAttribute()) {
+                    if ($pendingRouteAttribute instanceof Route) {
+                        $action->withTrashed = $pendingRouteAttribute->withTrashed;
+                    }
+                }
+
+                if ($actionAttribute = $action->getRouteAttribute()) {
+                    if ($actionAttribute instanceof Route) {
+                        $action->withTrashed = $actionAttribute->withTrashed;
+                    }
+                }
+            });
+        });
+    }
+}

--- a/src/PendingRoutes/PendingRouteAction.php
+++ b/src/PendingRoutes/PendingRouteAction.php
@@ -36,6 +36,8 @@ class PendingRouteAction
 
     public ?string $domain = null;
 
+    public bool $withTrashed = false;
+
     /**
      * @param ReflectionMethod $method
      * @param class-string $controllerClass

--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -125,6 +125,10 @@ class RouteRegistrar
                 if ($action->domain) {
                     $route->domain($action->domain);
                 }
+
+                if( $action->withTrashed ) {
+                    $route->withTrashed( $action->withTrashed );
+                }
             });
         });
     }

--- a/tests/RouteDiscoveryTest.php
+++ b/tests/RouteDiscoveryTest.php
@@ -34,6 +34,7 @@ use Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\ResourceMethods\
 use Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\ResourceMethodsWithUri\ResourceMethodsWithUriController;
 use Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\Single\MyController;
 use Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\Where\WhereAttributeController;
+use Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\WithTrashed\WithTrashedAttributeController;
 use Spatie\RouteDiscovery\Tests\Support\TestClasses\Middleware\OtherTestMiddleware;
 use Spatie\RouteDiscovery\Tests\Support\TestClasses\Middleware\TestMiddleware;
 
@@ -581,6 +582,25 @@ it('can handle a where attribute', function () {
         );
 });
 
+it('can handle a withTrashed attribute', function () {
+    $this
+        ->routeRegistrar
+        ->registerDirectory(controllersPath('WithTrashed'));
+
+    $this
+        ->assertRegisteredRoutesCount(2)
+        ->assertRouteRegistered(
+            WithTrashedAttributeController::class,
+            controllerMethod: 'show',
+            withTrashed: false,
+        )
+        ->assertRouteRegistered(
+            WithTrashedAttributeController::class,
+            controllerMethod: 'restore',
+            withTrashed: true,
+        );
+});
+
 it('can handle a domain attribute', function () {
     $this
         ->routeRegistrar
@@ -621,7 +641,8 @@ it('will make sure the routes whose uri start with parameters will be registered
 
     $this->assertRegisteredRoutesCount(3);
 
-    $registeredUris = collect(app()->router->getRoutes())
+
+    $registeredUris = collect($this->getRouteCollection()->getRoutes())
         ->map(fn (Route $route) => $route->uri)
         ->toArray();
 

--- a/tests/Support/TestClasses/Controllers/WithTrashed/WithTrashedAttributeController.php
+++ b/tests/Support/TestClasses/Controllers/WithTrashed/WithTrashedAttributeController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Spatie\RouteDiscovery\Tests\Support\TestClasses\Controllers\WithTrashed;
+
+use Illuminate\Foundation\Auth\User;
+use Spatie\RouteDiscovery\Attributes\Route;
+
+#[Route( withTrashed: true )]
+class WithTrashedAttributeController
+{
+    #[Route( withTrashed: false )]
+    public function show(User $user)
+    {
+    }
+
+    public function restore(User $user)
+    {
+    }
+}


### PR DESCRIPTION
Introduced the `withTrashed` parameter in the Route attribute to allow implicit binding of soft deleted models. Updated the RouteRegistrar and related classes to handle this new functionality. Added tests to verify the correct registration of routes with the `withTrashed` attribute.