### PR TITLE
Fix PHPStan error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "symfony/finder": "^5.4.2|^6.0|^7.0"
     },
     "require-dev": {
-        "nunomaduro/larastan": "^3.7",
+        "larastan/larastan": "^1.0|^2.0|^3.0",
         "orchestra/testbench": "^6.23.2|^7.0|^8.0|^9.0|^10.0",
         "pestphp/pest": "^1.21|^2.34|^3.7",
         "phpstan/extension-installer": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "symfony/finder": "^5.4.2|^6.0|^7.0"
     },
     "require-dev": {
+        "nunomaduro/larastan": "^3.7",
         "orchestra/testbench": "^6.23.2|^7.0|^8.0|^9.0|^10.0",
         "pestphp/pest": "^1.21|^2.34|^3.7",
         "phpstan/extension-installer": "^1.1",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,5 +9,4 @@ parameters:
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true
-    checkMissingIterableValueType: true
 


### PR DESCRIPTION
whit `./vendor/bin/phpstan analyse` there were these errors:

```
Invalid configuration:
Unexpected item 'parameters › checkOctaneCompatibility'.
Invalid configuration:
Unexpected item 'parameters › checkModelProperties'.
Invalid configuration:
Unexpected item 'parameters › checkMissingIterableValueType'.
Script vendor/bin/phpstan analyse handling the analyse event returned with error code 1
```

The phpstan.neon.dist configuration uses options (checkOctaneCompatibility, checkModelProperties, checkMissingIterableValueType) provided by Larastan, but the composer.json does not have nunomaduro/larastan installed, so PHPStan stops parsing.

- Added nunomaduro/larastan to the dev dependencies (composer.json, composer.lock) to support Larastan parameters.
- Cleaned up phpstan.neon.dist by removing the no longer supported checkMissingIterableValueType option.