### PR TITLE
Fix tests for Laravel 12/13

### DIFF
--- a/tests/Support/TestCase.php
+++ b/tests/Support/TestCase.php
@@ -25,6 +25,11 @@ class TestCase extends Orchestra
             ->useRootNamespace('Spatie\RouteDiscovery\Tests\Support\\');
     }
 
+    protected function defineEnvironment($app): void
+    {
+        $app['config']->set('filesystems.disks.local.serve', false);
+    }
+
     protected function getPackageProviders($app)
     {
         return [
@@ -123,11 +128,7 @@ class TestCase extends Orchestra
 
     public function getRouteCollection(): RouteCollection
     {
-        return tap(new RouteCollection, function ($collection) {
-            collect(app()->router->getRoutes()->getRoutes())
-                ->reject(fn ($route) => $route->getName() == 'storage.local')
-                ->each(fn ($route) => $collection->add($route));
-        });
+        return app()->router->getRoutes();
     }
 
     protected function registerControllersFromConfigFile(): self


### PR DESCRIPTION
## Summary
- Testbench 10+ (Laravel 12) registers a local filesystem serving route by default, causing all route count assertions to be off by 1
- Disable this route via config (`filesystems.disks.local.serve = false`) in `defineEnvironment`, matching the approach used in `spatie/laravel-route-attributes`
- Simplify `getRouteCollection()` by removing the now-unnecessary `storage.local` name rejection